### PR TITLE
Add offline STT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ async function sayHello() {
 | **stopRecognition** | `(): Promise<string>` | Finish decoding and return the recognised text. |
 | **deinitializeSTT** | `(): void` | Release STT resources. |
 
+### STT Quick Example
+
+```tsx
+import TTSManager from 'react-native-sherpa-onnx-offline-tts';
+import RNFS from 'react-native-fs';
+
+const cfg = JSON.stringify({
+  encoder: '/path/encoder.onnx',
+  decoder: '/path/decoder.onnx',
+  joiner: '/path/joiner.onnx',
+  tokens: '/path/tokens.txt',
+});
+
+async function recognise(path: string) {
+  await TTSManager.initSTT(cfg);
+  TTSManager.startRecognition();
+  const data = await RNFS.readFile(path, 'base64');
+  TTSManager.feedAudio(data);
+  const text = await TTSManager.stopRecognition();
+  console.log('Transcription:', text);
+}
+```
+
 ---
 
 ## 🔊 Supported Models

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ async function sayHello() {
 | **initSTT** | `(configJson: string): void` | Initialise offline speech recognition with model paths. |
 | **startRecognition** | `(): void` | Begin streaming audio from the device microphone. |
 | **feedAudio** | `(base64Pcm: string): void` | *(Optional)* Manually supply PCM16LE data. |
-| **stopRecognition** | `(): Promise<string>` | Finish decoding and return the recognised text. |
+| **stopRecognition** | `(): Promise<string>` | Stop streaming and get the transcription. |
 | **deinitializeSTT** | `(): void` | Release STT resources. |
 
 ### STT Quick Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-sherpa-onnx-offline-tts
 
-A lightweight React Native wrapper around [Sherpa‑ONNX](https://github.com/k2-fsa/sherpa-onnx) that lets you run **100 % offline Text‑to‑Speech** on iOS and Android.
+A lightweight React Native wrapper around [Sherpa‑ONNX](https://github.com/k2-fsa/sherpa-onnx) that lets you run **100 % offline Text‑to‑Speech** and **Speech‑to‑Text** on iOS and Android.
 
 ---
 
@@ -9,7 +9,7 @@ A lightweight React Native wrapper around [Sherpa‑ONNX](https://github.com/k2
 | | |
 |---|---|
 | 🔊 **Offline** – all synthesis happens on‑device, no network needed | ⚡ **Fast** – real‑time (or faster) generation on modern phones |
-| 🎙️ **Natural voices** – drop‑in support for Piper / VITS ONNX models | 🛠️ **Simple API** – a handful of async methods you already know |
+| 🎙️ **Natural voices** – drop‑in support for Piper / VITS ONNX models | 🛠️ **Simple API** – TTS & STT with a handful of async methods |
 
 ---
 
@@ -90,6 +90,11 @@ async function sayHello() {
 | **stopPlaying** | `(): void` | Immediately stops playback. |
 | **addVolumeListener** | `(cb: (volume: number) => void): EmitterSubscription` | Subscribes to real‑time RMS volume callbacks during playback. Call `subscription.remove()` to unsubscribe. |
 | **deinitialize** | `(): void` | Frees native resources – call this when your app unmounts or goes to background for a long time. |
+| **initSTT** | `(configJson: string): void` | Initialise offline speech recognition with model paths. |
+| **startRecognition** | `(): void` | Begin feeding audio samples for STT. |
+| **feedAudio** | `(base64Pcm: string): void` | Supply PCM16LE data to the recogniser. |
+| **stopRecognition** | `(): Promise<string>` | Finish decoding and return the recognised text. |
+| **deinitializeSTT** | `(): void` | Release STT resources. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ const cfg = JSON.stringify({
   tokens: '/path/tokens.txt',
 });
 
-async function recognise(path: string) {
+async function startListening() {
   await TTSManager.initSTT(cfg);
   TTSManager.startRecognition();
-  // speak for a few seconds then stop
-  await new Promise((r) => setTimeout(r, 5000));
+}
+
+async function stopListening() {
   const text = await TTSManager.stopRecognition();
   console.log('Transcription:', text);
 }

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ async function sayHello() {
 | **addVolumeListener** | `(cb: (volume: number) => void): EmitterSubscription` | Subscribes to real‑time RMS volume callbacks during playback. Call `subscription.remove()` to unsubscribe. |
 | **deinitialize** | `(): void` | Frees native resources – call this when your app unmounts or goes to background for a long time. |
 | **initSTT** | `(configJson: string): void` | Initialise offline speech recognition with model paths. |
-| **startRecognition** | `(): void` | Begin feeding audio samples for STT. |
-| **feedAudio** | `(base64Pcm: string): void` | Supply PCM16LE data to the recogniser. |
+| **startRecognition** | `(): void` | Begin streaming audio from the device microphone. |
+| **feedAudio** | `(base64Pcm: string): void` | *(Optional)* Manually supply PCM16LE data. |
 | **stopRecognition** | `(): Promise<string>` | Finish decoding and return the recognised text. |
 | **deinitializeSTT** | `(): void` | Release STT resources. |
 
@@ -112,8 +112,8 @@ const cfg = JSON.stringify({
 async function recognise(path: string) {
   await TTSManager.initSTT(cfg);
   TTSManager.startRecognition();
-  const data = await RNFS.readFile(path, 'base64');
-  TTSManager.feedAudio(data);
+  // speak for a few seconds then stop
+  await new Promise((r) => setTimeout(r, 5000));
   const text = await TTSManager.stopRecognition();
   console.log('Transcription:', text);
 }

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ async function sayHello() {
 | **addVolumeListener** | `(cb: (volume: number) => void): EmitterSubscription` | Subscribes to real‑time RMS volume callbacks during playback. Call `subscription.remove()` to unsubscribe. |
 | **deinitialize** | `(): void` | Frees native resources – call this when your app unmounts or goes to background for a long time. |
 | **initSTT** | `(configJson: string): void` | Initialise offline speech recognition with model paths. |
-| **startRecognition** | `(): void` | Begin streaming audio from the device microphone. |
-| **feedAudio** | `(base64Pcm: string): void` | *(Optional)* Manually supply PCM16LE data. |
-| **stopRecognition** | `(): Promise<string>` | Stop streaming and get the transcription. |
+| **startRecognition** | `(): void` | Begin capturing mic audio for offline decoding. |
+| **feedAudio** | `(base64Pcm: string): void` | *(Optional)* Append PCM16LE audio samples. |
+| **stopRecognition** | `(): Promise<string>` | Finish capture and return the transcription. |
 | **deinitializeSTT** | `(): void` | Release STT resources. |
 
 ### STT Quick Example
@@ -111,11 +111,11 @@ const cfg = JSON.stringify({
 
 async function startListening() {
   await TTSManager.initSTT(cfg);
-  TTSManager.startRecognition();
+  TTSManager.startRecognition(); // capture mic audio
 }
 
 async function stopListening() {
-  const text = await TTSManager.stopRecognition();
+  const text = await TTSManager.stopRecognition(); // decode offline
   console.log('Transcription:', text);
 }
 ```

--- a/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
+++ b/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
@@ -13,6 +13,9 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import org.json.JSONObject
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
 
 class ModelLoader(private val context: Context) {
 
@@ -89,6 +92,9 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     private var recognizer: OfflineRecognizer? = null
     private var sttStream: OfflineStream? = null
     private var sttSampleRate: Int = 16000
+    private var audioRecorder: AudioRecord? = null
+    private var recordingThread: Thread? = null
+    private var isRecording: Boolean = false
 
     override fun getName(): String {
         return "TTSManager"
@@ -167,10 +173,37 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
         recognizer = OfflineRecognizer(reactContext.assets, cfg)
     }
 
-    // Begin a recognition session
+    // Begin a recognition session from the microphone
     @ReactMethod
     fun startRecognition() {
         sttStream = recognizer?.createStream()
+        val minBuf = AudioRecord.getMinBufferSize(
+            sttSampleRate,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT
+        )
+        audioRecorder = AudioRecord(
+            MediaRecorder.AudioSource.MIC,
+            sttSampleRate,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+            minBuf
+        )
+        audioRecorder?.startRecording()
+        isRecording = true
+        recordingThread = thread(start = true) {
+            val buffer = ShortArray(1024)
+            while (isRecording) {
+                val read = audioRecorder!!.read(buffer, 0, buffer.size)
+                if (read > 0) {
+                    val floatSamples = FloatArray(read)
+                    for (i in 0 until read) {
+                        floatSamples[i] = buffer[i] / 32768.0f
+                    }
+                    sttStream?.acceptWaveform(floatSamples, sttSampleRate)
+                }
+            }
+        }
     }
 
     // Feed audio data as base64-encoded PCM16LE
@@ -189,6 +222,13 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     // Stop recognition and return the transcription
     @ReactMethod
     fun stopRecognition(promise: Promise) {
+        isRecording = false
+        recordingThread?.join()
+        recordingThread = null
+        audioRecorder?.stop()
+        audioRecorder?.release()
+        audioRecorder = null
+
         val stream = sttStream
         val rec = recognizer
         if (stream == null || rec == null) {
@@ -205,6 +245,12 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     // Release recognizer resources
     @ReactMethod
     fun deinitializeSTT() {
+        isRecording = false
+        recordingThread?.join()
+        recordingThread = null
+        audioRecorder?.stop()
+        audioRecorder?.release()
+        audioRecorder = null
         recognizer?.release()
         recognizer = null
         sttStream = null

--- a/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
+++ b/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
@@ -89,8 +89,8 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     private val modelLoader = ModelLoader(reactContext)
 
     // STT properties
-    private var recognizer: OnlineRecognizer? = null
-    private var sttStream: OnlineStream? = null
+    private var recognizer: OfflineRecognizer? = null
+    private var sttStream: OfflineStream? = null
     private var sttSampleRate: Int = 16000
     private var audioRecorder: AudioRecord? = null
     private var recordingThread: Thread? = null
@@ -154,8 +154,8 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
         val tokens = jsonObject.getString("tokens")
         sttSampleRate = jsonObject.optInt("sampleRate", 16000)
 
-        val modelConfig = OnlineModelConfig(
-            transducer = OnlineTransducerModelConfig(
+        val modelConfig = OfflineModelConfig(
+            transducer = OfflineTransducerModelConfig(
                 encoder = encoder,
                 decoder = decoder,
                 joiner = joiner
@@ -166,14 +166,9 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             provider = "cpu"
         )
         val feat = FeatureConfig(sttSampleRate, 80)
-        val endpoint = EndpointConfig()
-        val cfg = OnlineRecognizerConfig(
+        val cfg = OfflineRecognizerConfig(
             featConfig = feat,
             modelConfig = modelConfig,
-            lmConfig = OnlineLMConfig(),
-            ctcFstDecoderConfig = OnlineCtcFstDecoderConfig(),
-            endpointConfig = endpoint,
-            enableEndpoint = false,
             decodingMethod = "greedy_search",
             maxActivePaths = 4,
             hotwordsFile = "",
@@ -182,7 +177,7 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             ruleFars = "",
             blankPenalty = 0.0f
         )
-        recognizer = OnlineRecognizer(reactContext.assets, cfg)
+        recognizer = OfflineRecognizer(reactContext.assets, cfg)
     }
 
     // Begin a recognition session from the microphone
@@ -213,9 +208,6 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
                         floatSamples[i] = buffer[i] / 32768.0f
                     }
                     sttStream?.acceptWaveform(floatSamples, sttSampleRate)
-                    while (recognizer?.isReady(sttStream!!) == true) {
-                        recognizer?.decode(sttStream!!)
-                    }
                 }
             }
         }
@@ -232,9 +224,6 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             samples[i] = buf.short.toFloat() / 32768.0f
         }
         stream.acceptWaveform(samples, sttSampleRate)
-        while (recognizer?.isReady(stream) == true) {
-            recognizer?.decode(stream)
-        }
     }
 
     // Stop recognition and return the transcription
@@ -253,10 +242,7 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             promise.reject("NOT_READY", "Recognizer not ready")
             return
         }
-        stream.inputFinished()
-        while (rec.isReady(stream)) {
-            rec.decode(stream)
-        }
+        rec.decode(stream)
         val result = rec.getResult(stream)
         stream.release()
         sttStream = null

--- a/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
+++ b/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
@@ -89,8 +89,8 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     private val modelLoader = ModelLoader(reactContext)
 
     // STT properties
-    private var recognizer: OfflineRecognizer? = null
-    private var sttStream: OfflineStream? = null
+    private var recognizer: OnlineRecognizer? = null
+    private var sttStream: OnlineStream? = null
     private var sttSampleRate: Int = 16000
     private var audioRecorder: AudioRecord? = null
     private var recordingThread: Thread? = null
@@ -154,8 +154,8 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
         val tokens = jsonObject.getString("tokens")
         sttSampleRate = jsonObject.optInt("sampleRate", 16000)
 
-        val modelConfig = OfflineModelConfig(
-            transducer = OfflineTransducerModelConfig(
+        val modelConfig = OnlineModelConfig(
+            transducer = OnlineTransducerModelConfig(
                 encoder = encoder,
                 decoder = decoder,
                 joiner = joiner
@@ -166,11 +166,23 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             provider = "cpu"
         )
         val feat = FeatureConfig(sttSampleRate, 80)
-        val cfg = OfflineRecognizerConfig(
+        val endpoint = EndpointConfig()
+        val cfg = OnlineRecognizerConfig(
             featConfig = feat,
-            modelConfig = modelConfig
+            modelConfig = modelConfig,
+            lmConfig = OnlineLMConfig(),
+            ctcFstDecoderConfig = OnlineCtcFstDecoderConfig(),
+            endpointConfig = endpoint,
+            enableEndpoint = false,
+            decodingMethod = "greedy_search",
+            maxActivePaths = 4,
+            hotwordsFile = "",
+            hotwordsScore = 1.5f,
+            ruleFsts = "",
+            ruleFars = "",
+            blankPenalty = 0.0f
         )
-        recognizer = OfflineRecognizer(reactContext.assets, cfg)
+        recognizer = OnlineRecognizer(reactContext.assets, cfg)
     }
 
     // Begin a recognition session from the microphone
@@ -201,6 +213,9 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
                         floatSamples[i] = buffer[i] / 32768.0f
                     }
                     sttStream?.acceptWaveform(floatSamples, sttSampleRate)
+                    while (recognizer?.isReady(sttStream!!) == true) {
+                        recognizer?.decode(sttStream!!)
+                    }
                 }
             }
         }
@@ -217,6 +232,9 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             samples[i] = buf.short.toFloat() / 32768.0f
         }
         stream.acceptWaveform(samples, sttSampleRate)
+        while (recognizer?.isReady(stream) == true) {
+            recognizer?.decode(stream)
+        }
     }
 
     // Stop recognition and return the transcription
@@ -235,7 +253,10 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
             promise.reject("NOT_READY", "Recognizer not ready")
             return
         }
-        rec.decode(stream)
+        stream.inputFinished()
+        while (rec.isReady(stream)) {
+            rec.decode(stream)
+        }
         val result = rec.getResult(stream)
         stream.release()
         sttStream = null

--- a/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
+++ b/android/src/main/java/com/sherpaonnxofflinetts/TTSManagerModule.kt
@@ -3,6 +3,9 @@ package com.sherpaonnxofflinetts
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.k2fsa.sherpa.onnx.*
+import android.util.Base64
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import android.content.res.AssetManager
 import kotlin.concurrent.thread
 import android.content.Context
@@ -82,6 +85,11 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
     private var realTimeAudioPlayer: AudioPlayer? = null
     private val modelLoader = ModelLoader(reactContext)
 
+    // STT properties
+    private var recognizer: OfflineRecognizer? = null
+    private var sttStream: OfflineStream? = null
+    private var sttSampleRate: Int = 16000
+
     override fun getName(): String {
         return "TTSManager"
     }
@@ -130,6 +138,78 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
         realTimeAudioPlayer?.start()
     }
 
+    // Initialize offline speech recognizer
+    @ReactMethod
+    fun initializeSTT(modelId: String) {
+        val jsonObject = JSONObject(modelId)
+        val encoder = jsonObject.getString("encoder")
+        val decoder = jsonObject.getString("decoder")
+        val joiner = jsonObject.getString("joiner")
+        val tokens = jsonObject.getString("tokens")
+        sttSampleRate = jsonObject.optInt("sampleRate", 16000)
+
+        val modelConfig = OfflineModelConfig(
+            transducer = OfflineTransducerModelConfig(
+                encoder = encoder,
+                decoder = decoder,
+                joiner = joiner
+            ),
+            tokens = tokens,
+            numThreads = 1,
+            debug = true,
+            provider = "cpu"
+        )
+        val feat = FeatureConfig(sttSampleRate, 80)
+        val cfg = OfflineRecognizerConfig(
+            featConfig = feat,
+            modelConfig = modelConfig
+        )
+        recognizer = OfflineRecognizer(reactContext.assets, cfg)
+    }
+
+    // Begin a recognition session
+    @ReactMethod
+    fun startRecognition() {
+        sttStream = recognizer?.createStream()
+    }
+
+    // Feed audio data as base64-encoded PCM16LE
+    @ReactMethod
+    fun feedAudio(data: String) {
+        val stream = sttStream ?: return
+        val bytes = Base64.decode(data, Base64.DEFAULT)
+        val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val samples = FloatArray(bytes.size / 2)
+        for (i in samples.indices) {
+            samples[i] = buf.short.toFloat() / 32768.0f
+        }
+        stream.acceptWaveform(samples, sttSampleRate)
+    }
+
+    // Stop recognition and return the transcription
+    @ReactMethod
+    fun stopRecognition(promise: Promise) {
+        val stream = sttStream
+        val rec = recognizer
+        if (stream == null || rec == null) {
+            promise.reject("NOT_READY", "Recognizer not ready")
+            return
+        }
+        rec.decode(stream)
+        val result = rec.getResult(stream)
+        stream.release()
+        sttStream = null
+        promise.resolve(result.text)
+    }
+
+    // Release recognizer resources
+    @ReactMethod
+    fun deinitializeSTT() {
+        recognizer?.release()
+        recognizer = null
+        sttStream = null
+    }
+
     // Generate and Play method exposed to React Native
     @ReactMethod
     fun generateAndPlay(text: String, sid: Int, speed: Double, promise: Promise) {
@@ -159,6 +239,7 @@ class TTSManagerModule(private val reactContext: ReactApplicationContext) : Reac
         realTimeAudioPlayer = null
         tts?.release()
         tts = null
+        deinitializeSTT()
     }
 
     // Helper: split text into manageable chunks similar to iOS logic

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,6 +20,7 @@ const App = () => {
   const [downloadProgress, setDownloadProgress] = useState<number>(0);
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const [isListening, setIsListening] = useState<boolean>(false);
   const [transcript, setTranscript] = useState<string>('');
 
   // References
@@ -230,9 +231,9 @@ const App = () => {
   };
 
   /**
-   * Simple demo STT capturing from the microphone
+   * Begin STT capture from the microphone
    */
-  const handleSTT = async () => {
+  const handleStartSTT = async () => {
     try {
       await TTSManager.initSTT(
         JSON.stringify({
@@ -243,11 +244,23 @@ const App = () => {
         })
       );
       TTSManager.startRecognition();
-      await new Promise((res) => setTimeout(res, 5000));
+      setIsListening(true);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  /**
+   * Stop STT capture and display the result
+   */
+  const handleStopSTT = async () => {
+    try {
       const text = await TTSManager.stopRecognition();
       setTranscript(text);
     } catch (e) {
       console.error(e);
+    } finally {
+      setIsListening(false);
     }
   };
 
@@ -285,7 +298,16 @@ const App = () => {
               onPress={handleStop}
               disabled={!isPlaying}
             />
-            <Button title="Run STT" onPress={handleSTT} />
+            <Button
+              title="Start STT"
+              onPress={handleStartSTT}
+              disabled={isListening}
+            />
+            <Button
+              title="Stop STT"
+              onPress={handleStopSTT}
+              disabled={!isListening}
+            />
           </View>
           <View style={styles.volumeContainer}>
             <Text>Current Volume: {volume.toFixed(2)}</Text>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -230,12 +230,10 @@ const App = () => {
   };
 
   /**
-   * Simple demo STT using a bundled PCM file
+   * Simple demo STT capturing from the microphone
    */
   const handleSTT = async () => {
     try {
-      const audioPath = `${RNFS.DocumentDirectoryPath}/sample.pcm`;
-      const data = await RNFS.readFile(audioPath, 'base64');
       await TTSManager.initSTT(
         JSON.stringify({
           encoder: 'encoder.onnx',
@@ -245,7 +243,7 @@ const App = () => {
         })
       );
       TTSManager.startRecognition();
-      TTSManager.feedAudio(data);
+      await new Promise((res) => setTimeout(res, 5000));
       const text = await TTSManager.stopRecognition();
       setTranscript(text);
     } catch (e) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,6 +20,7 @@ const App = () => {
   const [downloadProgress, setDownloadProgress] = useState<number>(0);
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const [transcript, setTranscript] = useState<string>('');
 
   // References
   const animatedScale = useRef(new Animated.Value(1)).current;
@@ -228,6 +229,30 @@ const App = () => {
     console.log('Playback stopped.');
   };
 
+  /**
+   * Simple demo STT using a bundled PCM file
+   */
+  const handleSTT = async () => {
+    try {
+      const audioPath = `${RNFS.DocumentDirectoryPath}/sample.pcm`;
+      const data = await RNFS.readFile(audioPath, 'base64');
+      await TTSManager.initSTT(
+        JSON.stringify({
+          encoder: 'encoder.onnx',
+          decoder: 'decoder.onnx',
+          joiner: 'joiner.onnx',
+          tokens: 'tokens.txt',
+        })
+      );
+      TTSManager.startRecognition();
+      TTSManager.feedAudio(data);
+      const text = await TTSManager.stopRecognition();
+      setTranscript(text);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <View style={styles.container}>
       {/* Display Download Progress */}
@@ -262,9 +287,11 @@ const App = () => {
               onPress={handleStop}
               disabled={!isPlaying}
             />
+            <Button title="Run STT" onPress={handleSTT} />
           </View>
           <View style={styles.volumeContainer}>
             <Text>Current Volume: {volume.toFixed(2)}</Text>
+            <Text>Transcript: {transcript}</Text>
           </View>
         </>
       )}

--- a/ios/SherpaOnnxOfflineTts.mm
+++ b/ios/SherpaOnnxOfflineTts.mm
@@ -6,13 +6,21 @@
 RCT_EXTERN_METHOD(initializeTTS:(double)sampleRate channels:(NSInteger)channels modelId:(NSString *)modelId)
 
 // Generate and Play method exposed to React Native
-RCT_EXTERN_METHOD(generateAndPlay:(NSString *)text 
-                  sid:(NSInteger)sid 
-                  speed:(double)speed 
-                  resolver:(RCTPromiseResolveBlock)resolver 
+RCT_EXTERN_METHOD(generateAndPlay:(NSString *)text
+                  sid:(NSInteger)sid
+                  speed:(double)speed
+                  resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
 
 // Deinitialize method exposed to React Native
 RCT_EXTERN_METHOD(deinitialize)
+
+// STT APIs
+RCT_EXTERN_METHOD(initializeSTT:(NSString *)modelId)
+RCT_EXTERN_METHOD(startRecognition)
+RCT_EXTERN_METHOD(feedAudio:(NSString *)data)
+RCT_EXTERN_METHOD(stopRecognition:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(deinitializeSTT)
 
 @end

--- a/ios/SherpaOnnxOfflineTts.swift
+++ b/ios/SherpaOnnxOfflineTts.swift
@@ -16,6 +16,7 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     private var recognizer: SherpaOnnxOfflineRecognizer?
     private var sttSamples: [Float] = []
     private var sttSampleRate: Int = 16000
+    private var audioEngine: AVAudioEngine?
     
     override init() {
         super.init()
@@ -69,6 +70,19 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
 
     @objc func startRecognition() {
         sttSamples.removeAll()
+        audioEngine = AVAudioEngine()
+        guard let engine = audioEngine else { return }
+        let input = engine.inputNode
+        let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(sttSampleRate), channels: 1, interleaved: false)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            let count = Int(buffer.frameLength)
+            if let data = buffer.floatChannelData?[0] {
+                let samples = Array(UnsafeBufferPointer(start: data, count: count))
+                self.sttSamples.append(contentsOf: samples)
+            }
+        }
+        engine.prepare()
+        try? engine.start()
     }
 
     @objc func feedAudio(_ data: String) {
@@ -86,6 +100,9 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     }
 
     @objc func stopRecognition(_ resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) {
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
         guard let rec = recognizer else {
             rejecter("NOT_READY", "Recognizer not ready", nil)
             return
@@ -96,8 +113,10 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     }
 
     @objc func deinitializeSTT() {
-        recognizer = nil
+        audioEngine?.stop()
+        audioEngine = nil
         sttSamples.removeAll()
+        recognizer = nil
     }
 
     // Generate audio and play in real-time

--- a/ios/SherpaOnnxOfflineTts.swift
+++ b/ios/SherpaOnnxOfflineTts.swift
@@ -13,9 +13,10 @@ protocol AudioPlayerDelegate: AnyObject {
 class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     private var tts: SherpaOnnxOfflineTtsWrapper?
     private var realTimeAudioPlayer: AudioPlayer?
-    private var recognizer: SherpaOnnxRecognizer?
+    private var recognizer: SherpaOnnxOfflineRecognizer?
     private var sttSampleRate: Int = 16000
     private var audioEngine: AVAudioEngine?
+    private var capturedSamples: [Float] = []
     
     override init() {
         super.init()
@@ -51,39 +52,38 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
         let tokens = json["tokens"] as? String ?? ""
         sttSampleRate = json["sampleRate"] as? Int ?? 16000
 
-        var model = sherpaOnnxOnlineModelConfig(
+        var model = sherpaOnnxOfflineModelConfig(
             tokens: tokens,
-            transducer: sherpaOnnxOnlineTransducerModelConfig(
+            transducer: sherpaOnnxOfflineTransducerModelConfig(
                 encoder: encoder,
                 decoder: decoder,
                 joiner: joiner
             ),
             numThreads: 1,
-            debug: 1,
-            provider: "cpu"
+            provider: "cpu",
+            debug: 1
         )
         let feat = sherpaOnnxFeatureConfig(sampleRate: sttSampleRate)
-        var cfg = sherpaOnnxOnlineRecognizerConfig(
+        var cfg = sherpaOnnxOfflineRecognizerConfig(
             featConfig: feat,
             modelConfig: model,
-            enableEndpoint: false
+            decodingMethod: "greedy_search"
         )
-        recognizer = SherpaOnnxRecognizer(config: &cfg)
+        recognizer = SherpaOnnxOfflineRecognizer(config: &cfg)
     }
 
     @objc func startRecognition() {
         audioEngine = AVAudioEngine()
-        guard let engine = audioEngine, let rec = recognizer else { return }
+        capturedSamples.removeAll()
+        guard let engine = audioEngine else { return }
+        guard recognizer != nil else { return }
         let input = engine.inputNode
         let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(sttSampleRate), channels: 1, interleaved: false)
         input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
             let count = Int(buffer.frameLength)
             if let data = buffer.floatChannelData?[0] {
-                var samples = Array(UnsafeBufferPointer(start: data, count: count))
-                rec.acceptWaveform(samples: samples, sampleRate: self.sttSampleRate)
-                while rec.isReady() {
-                    rec.decode()
-                }
+                let samples = Array(UnsafeBufferPointer(start: data, count: count))
+                self.capturedSamples.append(contentsOf: samples)
             }
         }
         engine.prepare()
@@ -91,7 +91,7 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     }
 
     @objc func feedAudio(_ data: String) {
-        guard let bytes = Data(base64Encoded: data), let rec = recognizer else { return }
+        guard let bytes = Data(base64Encoded: data) else { return }
         let count = bytes.count / 2
         var samples = [Float]()
         samples.reserveCapacity(count)
@@ -101,10 +101,7 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
                 samples.append(Float(val) / 32768.0)
             }
         }
-        rec.acceptWaveform(samples: samples, sampleRate: sttSampleRate)
-        while rec.isReady() {
-            rec.decode()
-        }
+        capturedSamples.append(contentsOf: samples)
     }
 
     @objc func stopRecognition(_ resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) {
@@ -115,11 +112,8 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
             rejecter("NOT_READY", "Recognizer not ready", nil)
             return
         }
-        rec.inputFinished()
-        while rec.isReady() {
-            rec.decode()
-        }
-        let result = rec.getResult()
+        let result = rec.decode(samples: capturedSamples, sampleRate: sttSampleRate)
+        capturedSamples.removeAll()
         resolver(result.text)
     }
 
@@ -127,6 +121,7 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
         audioEngine?.stop()
         audioEngine = nil
         recognizer = nil
+        capturedSamples.removeAll()
     }
 
     // Generate audio and play in real-time

--- a/ios/SherpaOnnxOfflineTts.swift
+++ b/ios/SherpaOnnxOfflineTts.swift
@@ -13,6 +13,9 @@ protocol AudioPlayerDelegate: AnyObject {
 class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     private var tts: SherpaOnnxOfflineTtsWrapper?
     private var realTimeAudioPlayer: AudioPlayer?
+    private var recognizer: SherpaOnnxOfflineRecognizer?
+    private var sttSamples: [Float] = []
+    private var sttSampleRate: Int = 16000
     
     override init() {
         super.init()
@@ -35,6 +38,66 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
         self.realTimeAudioPlayer = AudioPlayer(sampleRate: sampleRate, channels: AVAudioChannelCount(channels))
         self.realTimeAudioPlayer?.delegate = self // Set delegate to receive volume updates
         self.tts = createOfflineTts(modelId: modelId)
+    }
+
+    // Initialize offline STT
+    @objc(initializeSTT:)
+    func initializeSTT(_ modelId: String) {
+        guard let data = modelId.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        let encoder = json["encoder"] as? String ?? ""
+        let decoder = json["decoder"] as? String ?? ""
+        let joiner = json["joiner"] as? String ?? ""
+        let tokens = json["tokens"] as? String ?? ""
+        sttSampleRate = json["sampleRate"] as? Int ?? 16000
+
+        var model = sherpaOnnxOfflineModelConfig(
+            tokens: tokens,
+            transducer: sherpaOnnxOfflineTransducerModelConfig(
+                encoder: encoder,
+                decoder: decoder,
+                joiner: joiner
+            ),
+            numThreads: 1,
+            debug: 1,
+            provider: "cpu"
+        )
+        let feat = sherpaOnnxFeatureConfig(sampleRate: sttSampleRate)
+        var cfg = sherpaOnnxOfflineRecognizerConfig(featConfig: feat, modelConfig: model)
+        recognizer = SherpaOnnxOfflineRecognizer(config: &cfg)
+    }
+
+    @objc func startRecognition() {
+        sttSamples.removeAll()
+    }
+
+    @objc func feedAudio(_ data: String) {
+        guard let bytes = Data(base64Encoded: data) else { return }
+        let count = bytes.count / 2
+        var local = [Float]()
+        local.reserveCapacity(count)
+        bytes.withUnsafeBytes { buf in
+            for i in 0..<count {
+                let val = buf.load(fromByteOffset: i*2, as: Int16.self)
+                local.append(Float(val) / 32768.0)
+            }
+        }
+        sttSamples.append(contentsOf: local)
+    }
+
+    @objc func stopRecognition(_ resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) {
+        guard let rec = recognizer else {
+            rejecter("NOT_READY", "Recognizer not ready", nil)
+            return
+        }
+        let result = rec.decode(samples: sttSamples, sampleRate: sttSampleRate)
+        sttSamples.removeAll()
+        resolver(result.text)
+    }
+
+    @objc func deinitializeSTT() {
+        recognizer = nil
+        sttSamples.removeAll()
     }
 
     // Generate audio and play in real-time
@@ -117,6 +180,8 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     @objc func deinitialize() {
         self.realTimeAudioPlayer?.stop()
         self.realTimeAudioPlayer = nil
+        self.tts = nil
+        deinitializeSTT()
     }
     
     // MARK: - AudioPlayerDelegate Method

--- a/ios/SherpaOnnxOfflineTts.swift
+++ b/ios/SherpaOnnxOfflineTts.swift
@@ -13,8 +13,7 @@ protocol AudioPlayerDelegate: AnyObject {
 class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     private var tts: SherpaOnnxOfflineTtsWrapper?
     private var realTimeAudioPlayer: AudioPlayer?
-    private var recognizer: SherpaOnnxOfflineRecognizer?
-    private var sttSamples: [Float] = []
+    private var recognizer: SherpaOnnxRecognizer?
     private var sttSampleRate: Int = 16000
     private var audioEngine: AVAudioEngine?
     
@@ -41,7 +40,7 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
         self.tts = createOfflineTts(modelId: modelId)
     }
 
-    // Initialize offline STT
+    // Initialize streaming STT
     @objc(initializeSTT:)
     func initializeSTT(_ modelId: String) {
         guard let data = modelId.data(using: .utf8),
@@ -52,9 +51,9 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
         let tokens = json["tokens"] as? String ?? ""
         sttSampleRate = json["sampleRate"] as? Int ?? 16000
 
-        var model = sherpaOnnxOfflineModelConfig(
+        var model = sherpaOnnxOnlineModelConfig(
             tokens: tokens,
-            transducer: sherpaOnnxOfflineTransducerModelConfig(
+            transducer: sherpaOnnxOnlineTransducerModelConfig(
                 encoder: encoder,
                 decoder: decoder,
                 joiner: joiner
@@ -64,21 +63,27 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
             provider: "cpu"
         )
         let feat = sherpaOnnxFeatureConfig(sampleRate: sttSampleRate)
-        var cfg = sherpaOnnxOfflineRecognizerConfig(featConfig: feat, modelConfig: model)
-        recognizer = SherpaOnnxOfflineRecognizer(config: &cfg)
+        var cfg = sherpaOnnxOnlineRecognizerConfig(
+            featConfig: feat,
+            modelConfig: model,
+            enableEndpoint: false
+        )
+        recognizer = SherpaOnnxRecognizer(config: &cfg)
     }
 
     @objc func startRecognition() {
-        sttSamples.removeAll()
         audioEngine = AVAudioEngine()
-        guard let engine = audioEngine else { return }
+        guard let engine = audioEngine, let rec = recognizer else { return }
         let input = engine.inputNode
         let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(sttSampleRate), channels: 1, interleaved: false)
         input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
             let count = Int(buffer.frameLength)
             if let data = buffer.floatChannelData?[0] {
-                let samples = Array(UnsafeBufferPointer(start: data, count: count))
-                self.sttSamples.append(contentsOf: samples)
+                var samples = Array(UnsafeBufferPointer(start: data, count: count))
+                rec.acceptWaveform(samples: samples, sampleRate: self.sttSampleRate)
+                while rec.isReady() {
+                    rec.decode()
+                }
             }
         }
         engine.prepare()
@@ -86,17 +91,20 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
     }
 
     @objc func feedAudio(_ data: String) {
-        guard let bytes = Data(base64Encoded: data) else { return }
+        guard let bytes = Data(base64Encoded: data), let rec = recognizer else { return }
         let count = bytes.count / 2
-        var local = [Float]()
-        local.reserveCapacity(count)
+        var samples = [Float]()
+        samples.reserveCapacity(count)
         bytes.withUnsafeBytes { buf in
             for i in 0..<count {
                 let val = buf.load(fromByteOffset: i*2, as: Int16.self)
-                local.append(Float(val) / 32768.0)
+                samples.append(Float(val) / 32768.0)
             }
         }
-        sttSamples.append(contentsOf: local)
+        rec.acceptWaveform(samples: samples, sampleRate: sttSampleRate)
+        while rec.isReady() {
+            rec.decode()
+        }
     }
 
     @objc func stopRecognition(_ resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock) {
@@ -107,15 +115,17 @@ class TTSManager: RCTEventEmitter, AudioPlayerDelegate {
             rejecter("NOT_READY", "Recognizer not ready", nil)
             return
         }
-        let result = rec.decode(samples: sttSamples, sampleRate: sttSampleRate)
-        sttSamples.removeAll()
+        rec.inputFinished()
+        while rec.isReady() {
+            rec.decode()
+        }
+        let result = rec.getResult()
         resolver(result.text)
     }
 
     @objc func deinitializeSTT() {
         audioEngine?.stop()
         audioEngine = nil
-        sttSamples.removeAll()
         recognizer = nil
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,4 +38,12 @@ export default {
   generateAndPlay,
   deinitialize,
   addVolumeListener,
+  // STT APIs
+  initSTT: (cfg: string) => TTSManager.initializeSTT(cfg),
+  startRecognition: () => TTSManager.startRecognition(),
+  feedAudio: (data: string) => TTSManager.feedAudio(data),
+  stopRecognition: async () => {
+    return await TTSManager.stopRecognition();
+  },
+  deinitializeSTT: () => TTSManager.deinitializeSTT(),
 };


### PR DESCRIPTION
## Summary
- extend Android/iOS native modules with offline speech recognition APIs
- expose STT helpers in JS
- showcase transcription in the example app
- update docs with new STT info

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e6f24fe0832ea9081339538bb030